### PR TITLE
Rebrand towards ITP react scripts

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1,5 +1,5 @@
 {
-  "projectName": "kcd-scripts",
+  "projectName": "itp-react-scripts",
   "projectOwner": "kentcdodds",
   "files": [
     "README.md"

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -11,7 +11,7 @@ never done that before, that's great! Check this free short video tutorial to
 learn how: http://kcd.im/pull-request
 -->
 
-- `kcd-scripts` version:
+- `itp-react-scripts` version:
 - `node` version:
 - `npm` (or `yarn`) version:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ Thanks for being willing to contribute!
 > pull requests from branches on your fork. To do this, run:
 >
 > ```
-> git remote add upstream https://github.com/kentcdodds/kcd-scripts.git
+> git remote add upstream https://github.com/inthepocket/itp-react-scripts.git
 > git fetch upstream
 > git branch --set-upstream-to=upstream/master master
 > ```
@@ -88,4 +88,4 @@ requests! Thanks!
 [semantic-release]: https://npmjs.com/package/semantic-release
 [convention]: https://github.com/conventional-changelog/conventional-changelog-angular/blob/ed32559941719a130bb0327f886d6a32a8cbc2ba/convention.md
 [all-contributors]: https://github.com/kentcdodds/all-contributors
-[issues]: https://github.com/kentcdodds/kcd-scripts/issues
+[issues]: https://github.com/inthepocket/itp-react-scripts/issues

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <div align="center">
-<h1>kcd-scripts 🛠📦</h1>
+<h1>itp-react-scripts 🛠📦</h1>
 
-<p>CLI toolbox for common scripts for my projects</p>
+<p>CLI toolbox for common scripts for ours projects</p>
 </div>
 
 <hr />
@@ -22,12 +22,12 @@
 
 ## The problem
 
-I do a bunch of open source and want to make it easier to maintain so many
+Make it easier for our agency to maintain so many
 projects.
 
 ## This solution
 
-This is a CLI that abstracts away all configuration for my open source projects
+This is a CLI that abstracts away all configuration for our open source projects
 for linting, testing, building, and more.
 
 ## Table of Contents
@@ -51,27 +51,27 @@ This module is distributed via [npm][npm] which is bundled with [node][node] and
 should be installed as one of your project's `devDependencies`:
 
 ```
-npm install --save-dev kcd-scripts
+npm install --save-dev itp-react-scripts
 ```
 
 ## Usage
 
-This is a CLI and exposes a bin called `kcd-scripts`. I don't really plan on
+This is a CLI and exposes a bin called `itp-react-scripts`. I don't really plan on
 documenting or testing it super duper well because it's really specific to my
 needs. You'll find all available scripts in `src/scripts`.
 
 This project actually dogfoods itself. If you look in the `package.json`, you'll
 find scripts with `node src {scriptName}`. This serves as an example of some
-of the things you can do with `kcd-scripts`.
+of the things you can do with `itp-react-scripts`.
 
 ### Overriding Config
 
-Unlike `react-scripts`, `kcd-scripts` allows you to specify your own
+Unlike `react-scripts`, `itp-react-scripts` allows you to specify your own
 configuration for things and have that plug directly into the way things work
-with `kcd-scripts`. There are various ways that it works, but basically if you
+with `itp-react-scripts`. There are various ways that it works, but basically if you
 want to have your own config for something, just add the configuration and
-`kcd-scripts` will use that instead of it's own internal config. In addition,
-`kcd-scripts` exposes its configuration so you can use it and override only
+`itp-react-scripts` will use that instead of it's own internal config. In addition,
+`itp-react-scripts` exposes its configuration so you can use it and override only
 the parts of the config you need to.
 
 This can be a very helpful way to make editor integration work for tools like
@@ -81,7 +81,7 @@ So, if we were to do this for ESLint, you could create an `.eslintrc` with the
 contents of:
 
 ```
-{"extends": "./node_modules/kcd-scripts/eslint.js"}
+{"extends": "./node_modules/itp-react-scripts/eslint.js"}
 ```
 
 > Note: for now, you'll have to include an `.eslintignore` in your project until
@@ -90,13 +90,13 @@ contents of:
 Or, for `babel`, a `.babelrc` with:
 
 ```
-{"presets": ["kcd-scripts/babel"]}
+{"presets": ["itp-react-scripts/babel"]}
 ```
 
 Or, for `jest`:
 
 ```javascript
-const {jest: jestConfig} = require('kcd-scripts/config')
+const {jest: jestConfig} = require('itp-react-scripts/config')
 module.exports = Object.assign(jestConfig, {
   // your overrides here
 
@@ -107,13 +107,14 @@ module.exports = Object.assign(jestConfig, {
 })
 ```
 
-> Note: `kcd-scripts` intentionally does not merge things for you when you start
+> Note: `itp-react-scripts` intentionally does not merge things for you when you start
 > configuring things to make it less magical and more straightforward. Extending
 > can take place on your terms. I think this is actually a great way to do this.
 
 ## Inspiration
 
-This is inspired by `react-scripts`.
+This library is a fork of [kcd-scripts](https://github.com/kentcdodds/kcd-scripts) by [Kent C. Dodds](https://kentcdodds.com/). Many thanks! 🙏
+His inspiration was `react-scripts`.
 
 ## Other Solutions
 
@@ -126,9 +127,9 @@ Thanks goes to these people ([emoji key][emojis]):
 
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
 <!-- prettier-ignore -->
-| [<img src="https://avatars.githubusercontent.com/u/1500684?v=3" width="100px;"/><br /><sub><b>Kent C. Dodds</b></sub>](https://kentcdodds.com)<br />[💻](https://github.com/kentcdodds/kcd-scripts/commits?author=kentcdodds "Code") [📖](https://github.com/kentcdodds/kcd-scripts/commits?author=kentcdodds "Documentation") [🚇](#infra-kentcdodds "Infrastructure (Hosting, Build-Tools, etc)") [⚠️](https://github.com/kentcdodds/kcd-scripts/commits?author=kentcdodds "Tests") | [<img src="https://avatars2.githubusercontent.com/u/22251956?v=4" width="100px;"/><br /><sub><b>Suhas Karanth</b></sub>](https://github.com/sudo-suhas)<br />[💻](https://github.com/kentcdodds/kcd-scripts/commits?author=sudo-suhas "Code") [🐛](https://github.com/kentcdodds/kcd-scripts/issues?q=author%3Asudo-suhas "Bug reports") [⚠️](https://github.com/kentcdodds/kcd-scripts/commits?author=sudo-suhas "Tests") | [<img src="https://avatars0.githubusercontent.com/u/1402095?v=4" width="100px;"/><br /><sub><b>Matt Parrish</b></sub>](https://github.com/pbomb)<br />[💻](https://github.com/kentcdodds/kcd-scripts/commits?author=pbomb "Code") [⚠️](https://github.com/kentcdodds/kcd-scripts/commits?author=pbomb "Tests") | [<img src="https://avatars3.githubusercontent.com/u/1319157?v=4" width="100px;"/><br /><sub><b>Mateus</b></sub>](https://github.com/mateuscb)<br />[💻](https://github.com/kentcdodds/kcd-scripts/commits?author=mateuscb "Code") [⚠️](https://github.com/kentcdodds/kcd-scripts/commits?author=mateuscb "Tests") | [<img src="https://avatars1.githubusercontent.com/u/2344137?v=4" width="100px;"/><br /><sub><b>Macklin Underdown</b></sub>](http://macklin.underdown.me)<br />[💻](https://github.com/kentcdodds/kcd-scripts/commits?author=macklinu "Code") [⚠️](https://github.com/kentcdodds/kcd-scripts/commits?author=macklinu "Tests") | [<img src="https://avatars2.githubusercontent.com/u/179534?v=4" width="100px;"/><br /><sub><b>stereobooster</b></sub>](https://github.com/stereobooster)<br />[💻](https://github.com/kentcdodds/kcd-scripts/commits?author=stereobooster "Code") [⚠️](https://github.com/kentcdodds/kcd-scripts/commits?author=stereobooster "Tests") | [<img src="https://avatars0.githubusercontent.com/u/410792?v=4" width="100px;"/><br /><sub><b>Dony Sukardi</b></sub>](http://dsds.io)<br />[🐛](https://github.com/kentcdodds/kcd-scripts/issues?q=author%3Adonysukardi "Bug reports") [💻](https://github.com/kentcdodds/kcd-scripts/commits?author=donysukardi "Code") |
+| [<img src="https://avatars.githubusercontent.com/u/1500684?v=3" width="100px;"/><br /><sub><b>Kent C. Dodds</b></sub>](https://kentcdodds.com)<br />[💻](https://github.com/kentcdodds/itp-react-scripts/commits?author=kentcdodds "Code") [📖](https://github.com/kentcdodds/itp-react-scripts/commits?author=kentcdodds "Documentation") [🚇](#infra-kentcdodds "Infrastructure (Hosting, Build-Tools, etc)") [⚠️](https://github.com/kentcdodds/itp-react-scripts/commits?author=kentcdodds "Tests") | [<img src="https://avatars2.githubusercontent.com/u/22251956?v=4" width="100px;"/><br /><sub><b>Suhas Karanth</b></sub>](https://github.com/sudo-suhas)<br />[💻](https://github.com/kentcdodds/itp-react-scripts/commits?author=sudo-suhas "Code") [🐛](https://github.com/kentcdodds/itp-react-scripts/issues?q=author%3Asudo-suhas "Bug reports") [⚠️](https://github.com/kentcdodds/itp-react-scripts/commits?author=sudo-suhas "Tests") | [<img src="https://avatars0.githubusercontent.com/u/1402095?v=4" width="100px;"/><br /><sub><b>Matt Parrish</b></sub>](https://github.com/pbomb)<br />[💻](https://github.com/kentcdodds/itp-react-scripts/commits?author=pbomb "Code") [⚠️](https://github.com/kentcdodds/itp-react-scripts/commits?author=pbomb "Tests") | [<img src="https://avatars3.githubusercontent.com/u/1319157?v=4" width="100px;"/><br /><sub><b>Mateus</b></sub>](https://github.com/mateuscb)<br />[💻](https://github.com/kentcdodds/itp-react-scripts/commits?author=mateuscb "Code") [⚠️](https://github.com/kentcdodds/itp-react-scripts/commits?author=mateuscb "Tests") | [<img src="https://avatars1.githubusercontent.com/u/2344137?v=4" width="100px;"/><br /><sub><b>Macklin Underdown</b></sub>](http://macklin.underdown.me)<br />[💻](https://github.com/kentcdodds/itp-react-scripts/commits?author=macklinu "Code") [⚠️](https://github.com/kentcdodds/itp-react-scripts/commits?author=macklinu "Tests") | [<img src="https://avatars2.githubusercontent.com/u/179534?v=4" width="100px;"/><br /><sub><b>stereobooster</b></sub>](https://github.com/stereobooster)<br />[💻](https://github.com/kentcdodds/itp-react-scripts/commits?author=stereobooster "Code") [⚠️](https://github.com/kentcdodds/itp-react-scripts/commits?author=stereobooster "Tests") | [<img src="https://avatars0.githubusercontent.com/u/410792?v=4" width="100px;"/><br /><sub><b>Dony Sukardi</b></sub>](http://dsds.io)<br />[🐛](https://github.com/kentcdodds/itp-react-scripts/issues?q=author%3Adonysukardi "Bug reports") [💻](https://github.com/kentcdodds/itp-react-scripts/commits?author=donysukardi "Code") |
 | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
-| [<img src="https://avatars3.githubusercontent.com/u/8997319?v=4" width="100px;"/><br /><sub><b>Alexander Nanberg</b></sub>](https://alexandernanberg.com)<br />[💻](https://github.com/kentcdodds/kcd-scripts/commits?author=alexandernanberg "Code") |
+| [<img src="https://avatars3.githubusercontent.com/u/8997319?v=4" width="100px;"/><br /><sub><b>Alexander Nanberg</b></sub>](https://alexandernanberg.com)<br />[💻](https://github.com/kentcdodds/itp-react-scripts/commits?author=alexandernanberg "Code") |
 
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "kcd-scripts",
+  "name": "itp-react-scripts",
   "version": "0.0.0-semantically-released",
   "description": "CLI for common scripts for my projects",
   "engines": {
@@ -7,7 +7,7 @@
     "npm": ">= 5"
   },
   "bin": {
-    "kcd-scripts": "dist/index.js"
+    "itp-react-scripts": "dist/index.js"
   },
   "scripts": {
     "add-contributor": "node src contributors add",
@@ -28,7 +28,7 @@
     "jest.js"
   ],
   "keywords": [],
-  "author": "Kent C. Dodds <kent@doddsfamily.us> (http://kentcdodds.com/)",
+  "author": "In The Pocket <hello@inthepocket.com> (http://inthepocket.com)",
   "license": "MIT",
   "dependencies": {
     "all-contributors-cli": "^5.0.0",
@@ -101,12 +101,12 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/kentcdodds/kcd-scripts.git"
+    "url": "https://github.com/inthepocket/itp-react-scripts.git"
   },
   "bugs": {
-    "url": "https://github.com/kentcdodds/kcd-scripts/issues"
+    "url": "https://github.com/inthepocket/itp-react-scripts/issues"
   },
-  "homepage": "https://github.com/kentcdodds/kcd-scripts#readme",
+  "homepage": "https://github.com/inthepocket/itp-react-scripts#readme",
   "devDependencies": {
     "jest-in-case": "^1.0.2",
     "slash": "^2.0.0"

--- a/src/__tests__/utils.js
+++ b/src/__tests__/utils.js
@@ -23,17 +23,17 @@ test('appDirectory is the dirname to the package.json', () => {
   expect(require('../utils').appDirectory).toBe(pkgPath)
 })
 
-test('resolveKcdScripts resolves to src/index.js when in the kcd-scripts package', () => {
-  mockPkg({pkg: {name: 'kcd-scripts'}})
-  expect(require('../utils').resolveKcdScripts()).toBe(
+test('resolveItpReactScripts resolves to src/index.js when in the itp-react-scripts package', () => {
+  mockPkg({pkg: {name: 'itp-react-scripts'}})
+  expect(require('../utils').resolveItpReactScripts()).toBe(
     require.resolve('../').replace(process.cwd(), '.'),
   )
 })
 
-test('resolveKcdScripts resolves to kcd-scripts if not in the kcd-scripts package', () => {
-  mockPkg({pkg: {name: 'not-kcd-scripts'}})
+test('resolveItpReactScripts resolves to itp-react-scripts if not in the itp-react-scripts package', () => {
+  mockPkg({pkg: {name: 'not-itp-react-scripts'}})
   whichSyncMock.mockImplementationOnce(() => require.resolve('../'))
-  expect(require('../utils').resolveKcdScripts()).toBe('kcd-scripts')
+  expect(require('../utils').resolveItpReactScripts()).toBe('itp-react-scripts')
 })
 
 test(`resolveBin resolves to the full path when it's not in $PATH`, () => {

--- a/src/config/lintstagedrc.js
+++ b/src/config/lintstagedrc.js
@@ -1,6 +1,6 @@
-const {resolveKcdScripts, resolveBin, isOptedOut} = require('../utils')
+const {resolveItpReactScripts, resolveBin, isOptedOut} = require('../utils')
 
-const kcdScripts = resolveKcdScripts()
+const kcdScripts = resolveItpReactScripts()
 const doctoc = resolveBin('doctoc')
 
 module.exports = {

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@
 let shouldThrow
 try {
   shouldThrow =
-    require(`${process.cwd()}/package.json`).name === 'kcd-scripts' &&
+    require(`${process.cwd()}/package.json`).name === 'itp-react-scripts' &&
     Number(process.version.slice(1).split('.')[0]) < 8
 } catch (error) {
   // ignore
@@ -10,7 +10,7 @@ try {
 
 if (shouldThrow) {
   throw new Error(
-    'You must use Node version 8 or greater to run the scripts within kcd-scripts ' +
+    'You must use Node version 8 or greater to run the scripts within itp-react-scripts ' +
       'because we dogfood the untranspiled version of the scripts.',
   )
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -12,11 +12,11 @@ const {pkg, path: pkgPath} = readPkgUp.sync({
 })
 const appDirectory = path.dirname(pkgPath)
 
-function resolveKcdScripts() {
-  if (pkg.name === 'kcd-scripts') {
+function resolveItpReactScripts() {
+  if (pkg.name === 'itp-react-scripts') {
     return require.resolve('./').replace(process.cwd(), '.')
   }
-  return resolveBin('kcd-scripts')
+  return resolveBin('itp-react-scripts')
 }
 
 // eslint-disable-next-line complexity
@@ -186,7 +186,7 @@ module.exports = {
   parseEnv,
   pkg,
   resolveBin,
-  resolveKcdScripts,
+  resolveItpReactScripts,
   uniq,
   writeExtraEntry,
 }


### PR DESCRIPTION
**What**:

Rebrand towards ITP react scripts

**Why**:

Because we will modify this according to the ITP needs

**How**:

* change kcd-scripts to itp-react-scripts

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [x] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [x] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
